### PR TITLE
Fix enum storage in generated schema templates

### DIFF
--- a/application/libraries/Schema_template_generator.php
+++ b/application/libraries/Schema_template_generator.php
@@ -213,7 +213,7 @@ class Schema_template_generator
 
     protected function build_field($schema, $path, $name, $is_required = false)
     {
-        return array(
+        $field = array(
             'key' => $path,
             'title' => $this->resolve_title($schema, $name),
             'type' => $this->normalize_type($schema),
@@ -221,6 +221,14 @@ class Schema_template_generator
             'help_text' => isset($schema['description']) ? $schema['description'] : '',
             'display_type' => $this->resolve_display_type($schema)
         );
+
+        $enum = $this->build_enum($schema);
+        if (!empty($enum)) {
+            $field['enum'] = $enum;
+            $field['enum_store_column'] = 'code';
+        }
+
+        return $field;
     }
 
     protected function build_array_field($schema, $path, $name, $depth, $is_required = false)
@@ -271,6 +279,12 @@ class Schema_template_generator
                     'help_text' => isset($child['description']) ? $child['description'] : '',
                     'display_type' => $this->resolve_display_type($child)
                 );
+
+                $enum = $this->build_enum($child);
+                if (!empty($enum)) {
+                    $props[count($props) - 1]['enum'] = $enum;
+                    $props[count($props) - 1]['enum_store_column'] = 'code';
+                }
             }
 
             return $props;
@@ -286,6 +300,12 @@ class Schema_template_generator
             'help_text' => isset($schema['description']) ? $schema['description'] : '',
             'display_type' => $this->resolve_display_type($schema)
         );
+
+        $enum = $this->build_enum($schema);
+        if (!empty($enum)) {
+            $props[count($props) - 1]['enum'] = $enum;
+            $props[count($props) - 1]['enum_store_column'] = 'code';
+        }
 
         return $props;
     }
@@ -315,10 +335,27 @@ class Schema_template_generator
                     return 'text';
                 }
                 if (isset($schema['enum']) && is_array($schema['enum']) && count($schema['enum']) > 0) {
-                    return 'select';
+                    return 'dropdown';
                 }
                 return 'text';
         }
+    }
+
+    protected function build_enum($schema)
+    {
+        if (!isset($schema['enum']) || !is_array($schema['enum']) || empty($schema['enum'])) {
+            return array();
+        }
+
+        $enum = array();
+        foreach ($schema['enum'] as $value) {
+            $enum[] = array(
+                'code' => $value,
+                'label' => (string)$value
+            );
+        }
+
+        return $enum;
     }
 
     protected function normalize_type($schema)
@@ -386,4 +423,3 @@ class Schema_template_generator
         return sha1(json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
 }
-

--- a/application/views/metadata_editor/vue-form-input-component.js
+++ b/application/views/metadata_editor/vue-form-input-component.js
@@ -49,12 +49,7 @@ Vue.component("form-input", {
       set: function (value) {
         let list = [];
         _.forEach(value, (code) => {
-          let enumCode = this.findEnumByCode(code);
-          if (enumCode) {
-            list.push(enumCode.label + " [" + enumCode.code + "]");
-          } else {
-            list.push(code);
-          }
+          list.push(this.getStoredEnumValue(code));
         });
         this.local = list;
       },
@@ -84,29 +79,13 @@ Vue.component("form-input", {
 
         //if enum_store_column is both, store the code and label
         if (enum_store_column == "both") {
-          let code = this.findEnumByCode(value);
-
-          if (code) {
-            this.local = code.label + " [" + code.code + "]";
-          } else {
-            this.local = value;
-          }
+          this.local = this.getStoredEnumValue(value, "both");
         }
         else if (enum_store_column == "code") {
-          let code = this.findEnumByCode(value);
-          if (code) {
-            this.local = code.code;
-          } else {
-            this.local = value;
-          }
+          this.local = this.getStoredEnumValue(value, "code");
         }
         else if (enum_store_column == "label") {
-          let code = this.findEnumByCode(value);
-          if (code) {
-            this.local = code.label;
-          } else {
-            this.local = value;
-          }
+          this.local = this.getStoredEnumValue(value, "label");
         }
         
       },
@@ -374,7 +353,40 @@ Vue.component("form-input", {
             </div>  `,
   methods: {
     findEnumByCode: function (code) {
+      if (code && typeof code === "object") {
+        if (Object.prototype.hasOwnProperty.call(code, "code")) {
+          code = code.code;
+        } else if (Object.prototype.hasOwnProperty.call(code, "value")) {
+          code = code.value;
+        }
+      }
+
       return _.find(this.field.enum, { code: code });
+    },
+    getEnumStoreColumn: function () {
+      if (this.field.enum_store_column) {
+        return this.field.enum_store_column;
+      }
+
+      return "both";
+    },
+    getStoredEnumValue: function (value, enumStoreColumn = null) {
+      const storeColumn = enumStoreColumn || this.getEnumStoreColumn();
+      const enumCode = this.findEnumByCode(value);
+
+      if (!enumCode) {
+        return value;
+      }
+
+      if (storeColumn == "code") {
+        return enumCode.code;
+      }
+
+      if (storeColumn == "label") {
+        return enumCode.label;
+      }
+
+      return enumCode.label + " [" + enumCode.code + "]";
     },
     getEnumCodeFromLabel: function (label) {
       //code is enclosed in [] e.g. label [code]


### PR DESCRIPTION
## Summary

Schema-generated enum fields are not stored in a way that is compatible with backend JSON Schema enum validation.

There are two related problems:

1. `Schema_template_generator` generates enum-backed fields without explicitly setting enum storage to the raw enum code.
2. The metadata editor frontend does not consistently honor `enum_store_column` for repeatable enum fields.

This can cause values like `No [no]` to be stored instead of `no`, which then fail JSON Schema validation against `enum: ["yes", "no"]`.

## Reproduction

1. Create or upload a JSON Schema with a string enum field, for example:
   ```json
   {
     "type": "string",
     "enum": ["yes", "no"]
   }

2. Let the app generate the default template from that schema.
3. Open a project using that generated template.
4. Select No in the editor.
5. Run schema validation.

## Actual Behavior
  
Validation fails with an enum error such as:

>  Does not have a value in the enumeration ["yes","no"]

because the stored value is a display value like `No [no]` instead of the schema enum value `no`. 

Repeatable enum fields have the same underlying problem when enum_store_column should be respected.

## Expected Behavior

Schema-generated enum fields should store the raw enum code by default, so selecting "No" stores `no`, and schema validation passes.

Repeatable enum fields should use the same storage rule as single-value enum fields.

## Fix

This PR does two things:

1. Updates Schema_template_generator so generated enum fields:
    - use a dropdown-compatible display type
    - include enum options in the template payload
    - set enum_store_column to code
2. Updates vue-form-input-component.js so repeatable enum fields also respect enum_store_column, instead of always storing Label [code].
